### PR TITLE
Make soc lights work

### DIFF
--- a/include/KS6eCAN.hpp
+++ b/include/KS6eCAN.hpp
@@ -28,7 +28,7 @@
 #define ID_VCU_WS_READINGS                  0xC6
 #define ID_DASH_BUTTONS                     0xEB
 #define ID_BMS_INFO                         0x6B1
-#define ID_BMS_SOC                          0x7FF //TODO make this real on the BMS
+#define ID_BMS_SOC                          0x6B3 //TODO make this real on the BMS
 // number of rx and tx mailboxes
 #define NUM_TX_MAILBOXES 2
 #define NUM_RX_MAILBOXES 6

--- a/include/KS6eDashGPIO.hpp
+++ b/include/KS6eDashGPIO.hpp
@@ -11,7 +11,7 @@ const int fault_led_gpios[]={INVERTER_LED,BSPD_LED,AMS_LED,IMD_LED};
 #define LED_A 4
 #define LED_B 5
 #define LED_C 6
-#define LED_D 6
+#define LED_D 7
 #define LATCH_1 9
 const int seven_seg_gpios[]={LED_A,LED_B,LED_C,LED_D,LATCH_1};
 

--- a/include/neopixel_defs.hpp
+++ b/include/neopixel_defs.hpp
@@ -1,7 +1,7 @@
 #ifndef NEOPIXEL_DEFS_HPP
 #define NEOPIXEL_DEFS_HPP
-#define NUMBER_OF_PIXELS 17
-#define PIXELS_FOR_SOC 10
+#define NUMBER_OF_PIXELS 17 //THere are seventeen total neopixels on the board
+#define PIXELS_FOR_SOC 11 //There are eleven neopixels on the top row intended for SOC
 // neo-pixel specific
 // color values are 0-255 (8 bits)
 // first byte is red, second is green, third is blue

--- a/src/flexcan_handle.cpp
+++ b/src/flexcan_handle.cpp
@@ -73,7 +73,8 @@ void update_can(){
         {
         case (ID_BMS_SOC):
         {
-            state_of_charge = rx_msg.buf[0];
+            //the BMS multiples the SOC value by two when it sends it, have to divide by two when received
+            state_of_charge = rx_msg.buf[0] / 2;
             break;
         }
         case (ID_VCU_STATUS):

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -55,6 +55,7 @@ uint8_t getButtons();
 void updateSOCNeopixels(int soc);
 void updateStatusNeopixels(MCU_status MCU_status);
 void test_socpixels();
+void set_single_segment_indicator(uint8_t number_to_display);
 
 void setup() {
   init_can();
@@ -277,4 +278,23 @@ void test_socpixels(){
     Serial.println(i);
     delay(100);
   }
+}
+//This method is not currently used because the seven segment on the KS6e
+//Dash doesn't work (because of schematic mistakes)
+//It should be kept here tho
+void set_single_segment_indicator(uint8_t number_to_display){
+  digitalWrite(LATCH_1,HIGH);
+  bool led_a_high = number_to_display && 0b0001;
+  bool led_b_high = number_to_display && 0b0010;
+  bool led_c_high = number_to_display && 0b0100;
+  bool led_d_high = number_to_display && 0b1000;
+  #if DEBUG
+  Serial.printf("SEVEN SEGMENT A: %d B: %d C: %d D: %d");
+  #endif
+  digitalWrite(LED_A,led_a_high);
+  digitalWrite(LED_B,led_b_high);
+  digitalWrite(LED_C,led_c_high);
+  digitalWrite(LED_D,led_d_high);
+  // there may need to be a delay here, but dont want to block
+digitalWrite(LATCH_1,LOW);
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -70,10 +70,6 @@ void loop() {
     updateStatusNeopixels(vcu_status);
     leds.show();
   }
-  // if(send_buttons_timer.check()){
-  //   uint8_t buf[]={getButtons(),0,0,0,0,0,0,0};
-  //   load_can(ID_DASH_BUTTONS,false,buf);
-  // }
     if(send_buttons_timer.check()){
     uint8_t buf[]={getButtons(),0,0,0,0,0,0,0};
     load_can(ID_DASH_BUTTONS,false,buf);
@@ -102,8 +98,9 @@ void loop() {
 
     digitalWrite(IMD_LED,!(vcu_status.get_imd_ok_high()));
     Serial.printf("This is the IMD OK HIGH boolean: %d\n",vcu_status.get_imd_ok_high());
-
+    //For the inverter fault, we OR all the fault fields, since fault code < 0 == bad == turn light on
     digitalWrite(INVERTER_LED,(mc_fault_codes.get_post_fault_hi() | mc_fault_codes.get_post_fault_lo() | mc_fault_codes.get_run_fault_hi() | mc_fault_codes.get_run_fault_lo()));
+    Serial.printf("These are the Inverter Fault Codes: Post_fault_hi: %d Post_fault_lo: %d Run_fault_hi: %d Run_fault_lo: %d\n",mc_fault_codes.get_post_fault_hi(),mc_fault_codes.get_post_fault_lo(),mc_fault_codes.get_run_fault_hi(),mc_fault_codes.get_run_fault_lo());
   }
 
 
@@ -190,6 +187,9 @@ uint8_t getButtons(){
  * @param soc 
  */
 void updateSOCNeopixels(int soc){
+  #if DEBUG
+  Serial.printf("State of charge value in neopixel update method: %d\n",soc);
+  #endif
   if(soc > 100){soc=100;}else if(soc<0){soc=0;}
   float soc_f = soc;
   soc_f /= 100;
@@ -225,7 +225,7 @@ void updateStatusNeopixels(MCU_status mcu_status){
   switch (mcu_status.get_state()){
     case MCU_STATE::STARTUP:
     {
-      status_color=WHITE;
+      status_color=BLUE;
       break;
     }
     case MCU_STATE::TRACTIVE_SYSTEM_NOT_ACTIVE:


### PR DESCRIPTION
- added BMS state of charge message ID

- added division by 2 of the state of charge message data since the BMS multiplies it by two when it sends it

- changed number of SOC indication LEDs to 11 because it is 11 and not 10

- plugged into car and verified shit works